### PR TITLE
Adding support for labeled filters

### DIFF
--- a/lib/google-site-search.rb
+++ b/lib/google-site-search.rb
@@ -88,7 +88,7 @@ module GoogleSiteSearch
 
 		# Google's api will give back a full query which has the filter options on it. I like to deal with them separately so this method breaks them up.
 		def separate_search_term_from_filters(string)
-			match = /\smore:p.*/.match(string)
+			match = /\smore(?:(?:(?::p:|:pagemap:).*)|(?::\w+\z))/.match(string)
 			return [string, nil] if match.nil?
 			return [match.pre_match.strip, match[0].strip] 
 		end

--- a/lib/google-site-search.rb
+++ b/lib/google-site-search.rb
@@ -86,12 +86,15 @@ module GoogleSiteSearch
       uri.relative? ? path : [uri.path,uri.query].compact.join("?")
     end
 
-		# Google's api will give back a full query which has the filter options on it. I like to deal with them separately so this method breaks them up.
-		def separate_search_term_from_filters(string)
-			match = /\smore(?:(?:(?::p:|:pagemap:).*\z)|(?::\w+\z))/.match(string)
-			return [string, nil] if match.nil?
-			return [match.pre_match.strip, match[0].strip] 
-		end
+    # Google's api will give back a full query which has the filter options on it. I like to deal with them separately so this method breaks them up.
+    def separate_search_term_from_filters(string)
+      if match = string.to_s.match(/\A(.*?)(more:.+)|.*\z/)
+        search_string, filters = match[1] || match[0], match[2]
+        [search_string.to_s.strip, filters.to_s.strip]
+      else
+        ['', '']
+      end
+    end
 
   end
 end

--- a/lib/google-site-search.rb
+++ b/lib/google-site-search.rb
@@ -88,7 +88,7 @@ module GoogleSiteSearch
 
 		# Google's api will give back a full query which has the filter options on it. I like to deal with them separately so this method breaks them up.
 		def separate_search_term_from_filters(string)
-			match = /\smore(?:(?:(?::p:|:pagemap:).*)|(?::\w+\z))/.match(string)
+			match = /\smore(?:(?:(?::p:|:pagemap:).*\z)|(?::\w+\z))/.match(string)
 			return [string, nil] if match.nil?
 			return [match.pre_match.strip, match[0].strip] 
 		end

--- a/lib/google-site-search/result.rb
+++ b/lib/google-site-search/result.rb
@@ -20,7 +20,7 @@ module GoogleSiteSearch
 
       #check for custom search description when not regular search result
       if @description.empty?
-        @description = node.find_first("//BLOCK /T").try(:content)
+        @description = node.find_first(".//BLOCK /T").try(:content)
       end
 		end
 	end

--- a/lib/google-site-search/result.rb
+++ b/lib/google-site-search/result.rb
@@ -11,7 +11,6 @@ module GoogleSiteSearch
 		#
 		# * +node+ - LibXML::XML::Node.
 		def initialize(node)
-			@description = nil
 			@title = node.find_first("T").try(:content)
 
 			# Fully qualified URL to the result.

--- a/lib/google-site-search/result.rb
+++ b/lib/google-site-search/result.rb
@@ -11,6 +11,7 @@ module GoogleSiteSearch
 		#
 		# * +node+ - LibXML::XML::Node.
 		def initialize(node)
+			@description = nil
 			@title = node.find_first("T").try(:content)
 
 			# Fully qualified URL to the result.

--- a/lib/google-site-search/result.rb
+++ b/lib/google-site-search/result.rb
@@ -1,12 +1,12 @@
 module GoogleSiteSearch
 
-	# A default class that parses a result element from 
+	# A default class that parses a result element from
 	# Googles search API.
 	#
 	# See {LibXML Ruby's Node}[http://libxml.rubyforge.org/rdoc/classes/LibXML/XML/Node.html] when writing your own Result class.
 	class Result
 		attr_reader :title, :link, :description
-		
+
 		# ==== Attributes
 		#
 		# * +node+ - LibXML::XML::Node.
@@ -17,6 +17,11 @@ module GoogleSiteSearch
 			@link = node.find_first("UE").try(:content)
 
 			@description = node.find_first("S").try(:content)
+
+      #check for custom search description when not regular search result
+      if @description.empty?
+        @description = node.find_first("//BLOCK /T").try(:content)
+      end
 		end
 	end
 end

--- a/lib/google-site-search/result.rb
+++ b/lib/google-site-search/result.rb
@@ -11,12 +11,12 @@ module GoogleSiteSearch
 		#
 		# * +node+ - LibXML::XML::Node.
 		def initialize(node)
-			@title = node.find_first("T").content
+			@title = node.find_first("T").try(:content)
 
 			# Fully qualified URL to the result.
-			@link = node.find_first("UE").content
+			@link = node.find_first("UE").try(:content)
 
-			@description = node.find_first("S").content
+			@description = node.find_first("S").try(:content)
 		end
 	end
 end

--- a/test/google_site_search_test.rb
+++ b/test/google_site_search_test.rb
@@ -85,6 +85,10 @@ describe GoogleSiteSearch do
     it 'strips whitespace' do
       GoogleSiteSearch.separate_search_term_from_filters(" microsoft  more:p:my-value  ").must_equal ["microsoft", "more:p:my-value"]
     end
+    
+    it 'works with labeled filters' do
+      GoogleSiteSearch.separate_search_term_from_filters("microsoft  more:software").must_equal ["microsoft", "more:software"]
+    end
 
     it 'handles nil' do
       GoogleSiteSearch.separate_search_term_from_filters(nil).must_equal [nil, nil]

--- a/test/google_site_search_test.rb
+++ b/test/google_site_search_test.rb
@@ -78,10 +78,6 @@ describe GoogleSiteSearch do
       GoogleSiteSearch.separate_search_term_from_filters("microsoft more:pagemap:mytype").must_equal ["microsoft", "more:pagemap:mytype"]
     end
 
-    it 'not fooled by an improper filter' do
-      GoogleSiteSearch.separate_search_term_from_filters("microsoft more:x:wrong").must_equal ["microsoft more:x:wrong", nil]
-    end
-
     it 'strips whitespace' do
       GoogleSiteSearch.separate_search_term_from_filters(" microsoft  more:p:my-value  ").must_equal ["microsoft", "more:p:my-value"]
     end
@@ -89,13 +85,25 @@ describe GoogleSiteSearch do
     it 'works with labeled filters' do
       GoogleSiteSearch.separate_search_term_from_filters("microsoft  more:software").must_equal ["microsoft", "more:software"]
     end
+    
+    it 'works with multiple implicit AND filters' do
+      GoogleSiteSearch.separate_search_term_from_filters("microsoft  more:software more:hardware").must_equal ["microsoft", "more:software more:hardware"]
+    end
+    
+    it 'works with multiple explicit AND filters' do
+      GoogleSiteSearch.separate_search_term_from_filters("microsoft  more:software AND more:hardware").must_equal ["microsoft", "more:software AND more:hardware"]
+    end
+    
+    it 'works with multiple explicit OR filters' do
+      GoogleSiteSearch.separate_search_term_from_filters("microsoft  more:software OR more:hardware").must_equal ["microsoft", "more:software OR more:hardware"]
+    end
 
     it 'handles nil' do
-      GoogleSiteSearch.separate_search_term_from_filters(nil).must_equal [nil, nil]
+      GoogleSiteSearch.separate_search_term_from_filters(nil).must_equal ["", ""]
     end
 
     it 'handles ""' do
-      GoogleSiteSearch.separate_search_term_from_filters("").must_equal ["", nil]
+      GoogleSiteSearch.separate_search_term_from_filters("").must_equal ["", ""]
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,6 @@ require "google-site-search"
 require "minitest/spec"
 require "minitest/mock"
 require 'minitest/autorun'
-require "mocha"
+require "mocha/setup"
 
 include GoogleSiteSearch #include module so I don't have to namespace everything


### PR DESCRIPTION
Some filters are not of `more:p:whatever` format. You can actually have `more:whatever` if you used labels for searched urls.
